### PR TITLE
Implement athp_update_slot().

### DIFF
--- a/otus/freebsd/src/sys/dev/athp/if_athp_mac2.h
+++ b/otus/freebsd/src/sys/dev/athp/if_athp_mac2.h
@@ -90,4 +90,6 @@ extern	int ath10k_update_wme_vap(struct ieee80211vap *vap,
 	    const struct wmeParams *wme_params);
 extern	void athp_bss_info_config(struct ieee80211vap *vap, struct ieee80211_node *);
 
+extern	void ath10k_bss_info_changed_slottime(struct ieee80211com *);
+
 #endif


### PR DESCRIPTION
Implement athp_update_slot().  The actual work needs to run in a
taskq, as otherwise we are sleeping on a non-sleepable lock.
This is a first cut based on athp_bss_info_config() or rather
ath10k_bss_info_changed().
We should probably factor out there other parts and generalise
ath10k_bss_info_changed_slottime() to handle them all and make
the callers do the setup in a next step.

Fixes Issue #27

Sponsored by: Rubicon Communications, LLC (d/b/a "Netgate")