### PR TITLE
Fix fw_log uninitialised mutex with tunable

### DIFF
--- a/otus/freebsd/src/sys/dev/athp/if_athp_core.c
+++ b/otus/freebsd/src/sys/dev/athp/if_athp_core.c
@@ -1737,7 +1737,7 @@ ath10k_core_register_work(void *arg, int npending)
 		goto err_release_fw;
 	}
 
-	ath10k_fwlog_register(ar);
+	/* See athp_pci. ath10k_fwlog_register(ar); */
 
 	status = ath10k_debug_register(ar);
 	if (status) {

--- a/otus/freebsd/src/sys/dev/athp/if_athp_pci.c
+++ b/otus/freebsd/src/sys/dev/athp/if_athp_pci.c
@@ -88,6 +88,7 @@ __FBSDID("$FreeBSD$");
 #include "if_athp_buf.h"
 #include "if_athp_trace.h"
 #include "if_athp_ioctl.h"
+#include "if_athp_fwlog.h"
 
 static device_probe_t athp_pci_probe;
 static device_attach_t athp_pci_attach;
@@ -716,6 +717,9 @@ athp_pci_attach(device_t dev)
 	    ATH10K_DBG_WMI_PRINT | ATH10K_DBG_MGMT | ATH10K_DBG_DATA | ATH10K_DBG_HTT;
 #endif
 	ar->sc_psc = ar_pci;
+
+	/* Attach the log to gather information early if tunable is set. */
+	ath10k_fwlog_register(ar);
 
 	/* Load-time tunable/sysctl tree */
 	athp_attach_sysctl(ar);


### PR DESCRIPTION
Initialise the firmware_log early on before the tunables are read
as after that we might get into the log functions passing the
bitmask and would panic as the mutex would not be initialised.

Fixes Issue #31.

Sponsored by: Rubicon Communications, LLC (d/b/a "Netgate")