### PR TITLE
Various cleanups

### DIFF
--- a/otus/freebsd/src/sys/dev/athp/if_athp_mac.c
+++ b/otus/freebsd/src/sys/dev/athp/if_athp_mac.c
@@ -6709,10 +6709,10 @@ exit:
 }
 #endif
 
+#if 0
 static int ath10k_conf_tx_uapsd(struct ath10k *ar, struct ieee80211vap *vif,
 				u16 ac, bool enable)
 {
-#if 0
 	struct ath10k_vif *arvif = ath10k_vif_to_arvif(vif);
 	struct wmi_sta_uapsd_auto_trig_arg arg = {};
 	u32 prio = 0, acc = 0;
@@ -6814,11 +6814,10 @@ static int ath10k_conf_tx_uapsd(struct ath10k *ar, struct ieee80211vap *vif,
 
 exit:
 	return ret;
-#else
 	ath10k_warn(ar, "%s: TODO!\n", __func__);
 	return (0);
-#endif
 }
+#endif
 
 /*
  * This is called only in the STA path for now, but yes, it should also

--- a/otus/freebsd/src/sys/dev/athp/if_athp_mac.c
+++ b/otus/freebsd/src/sys/dev/athp/if_athp_mac.c
@@ -1084,7 +1084,9 @@ void ath10k_mac_vif_beacon_free(struct ath10k_vif *arvif)
 
 static void ath10k_mac_vif_beacon_cleanup(struct ath10k_vif *arvif)
 {
+#ifdef INVARIANTS
 	struct ath10k *ar = arvif->ar;
+#endif
 
 	ATHP_DATA_LOCK_ASSERT(ar);
 
@@ -2445,6 +2447,7 @@ void ath10k_mac_handle_beacon_miss(struct ath10k *ar, u32 vdev_id)
 #endif
 }
 
+#if 0
 static void
 ath10k_mac_vif_sta_connection_loss_work(void *arg)
 {
@@ -2460,6 +2463,7 @@ ath10k_mac_vif_sta_connection_loss_work(void *arg)
 	ath10k_warn(ar, "%s: called!\n", __func__);
 //	ieee80211_connection_loss(vif);
 }
+#endif
 
 /**********************/
 /* Station management */
@@ -7085,23 +7089,23 @@ ath10k_tx_flush_locked(struct ath10k *ar, struct ieee80211vap *vif, u32 queues,
 		goto skip;
 
 	while (! ieee80211_time_after(ticks, interval)) {
-			bool empty;
+		bool empty;
 
-			time_left = ath10k_wait_wait(&ar->htt.empty_tx_wq,
-			    "tx_flush", &ar->sc_conf_mtx,
-			    ATH10K_FLUSH_TIMEOUT_HZ);
+		time_left = ath10k_wait_wait(&ar->htt.empty_tx_wq,
+		    "tx_flush", &ar->sc_conf_mtx,
+		    ATH10K_FLUSH_TIMEOUT_HZ);
 
-			ATHP_HTT_TX_LOCK(&ar->htt);
-			empty = (ar->htt.num_pending_tx == 0);
-			ATHP_HTT_TX_UNLOCK(&ar->htt);
+		ATHP_HTT_TX_LOCK(&ar->htt);
+		empty = (ar->htt.num_pending_tx == 0);
+		ATHP_HTT_TX_UNLOCK(&ar->htt);
 
-			skip = (ar->state == ATH10K_STATE_WEDGED) ||
-			       test_bit(ATH10K_FLAG_CRASH_FLUSH,
-					&ar->dev_flags);
+		skip = (ar->state == ATH10K_STATE_WEDGED) ||
+		       test_bit(ATH10K_FLAG_CRASH_FLUSH,
+				&ar->dev_flags);
 
-			if (empty || skip)
-				break;
-		}
+		if (empty || skip)
+			break;
+	}
 
 	if (time_left == 0 || skip)
 		ath10k_warn(ar, "failed to flush transmit queue (skip %i ar-state %i): %ld\n",
@@ -8971,7 +8975,9 @@ athp_vif_update_txpower(struct ieee80211vap *vap)
 int
 athp_vif_update_ap_ssid(struct ieee80211vap *vap, struct ieee80211_node *ni)
 {
+#ifdef INVARIANTS
 	struct ath10k *ar = vap->iv_ic->ic_softc;
+#endif
 	struct ath10k_vif *arvif = ath10k_vif_to_arvif(vap);
 
 	ATHP_CONF_LOCK_ASSERT(ar);
@@ -9145,7 +9151,9 @@ athp_vif_ap_setup(struct ieee80211vap *vap, struct ieee80211_node *ni)
 int
 athp_vif_ap_stop(struct ieee80211vap *vap, struct ieee80211_node *ni)
 {
+#ifdef INVARIANTS
 	struct ath10k *ar = vap->iv_ic->ic_softc;
+#endif
 	struct ath10k_vif *arvif = ath10k_vif_to_arvif(vap);
 
 	ATHP_CONF_LOCK_ASSERT(ar);

--- a/otus/freebsd/src/sys/dev/athp/if_athp_main.c
+++ b/otus/freebsd/src/sys/dev/athp/if_athp_main.c
@@ -2132,7 +2132,7 @@ athp_attach_sysctl(struct ath10k *ar)
 	struct sysctl_ctx_list *ctx = device_get_sysctl_ctx(ar->sc_dev);
 	struct sysctl_oid_list *child = SYSCTL_CHILDREN(tree);
 
-	SYSCTL_ADD_QUAD(ctx, child, OID_AUTO, "debug",
+	SYSCTL_ADD_UQUAD(ctx, child, OID_AUTO, "debug",
 	    CTLFLAG_RW | CTLFLAG_RWTUN,
 	    &ar->sc_debug, "debug control");
 	SYSCTL_ADD_INT(ctx, child, OID_AUTO, "hwcrypt_mode",
@@ -2148,29 +2148,29 @@ athp_attach_sysctl(struct ath10k *ar)
 	    CTLTYPE_INT | CTLFLAG_RW, ar, 0, athp_sysctl_fw_stats, "I", "");
 
 	/* statistics */
-	SYSCTL_ADD_QUAD(ctx, child, OID_AUTO, "stats_rx_msdu_invalid_len", CTLFLAG_RD,
+	SYSCTL_ADD_UQUAD(ctx, child, OID_AUTO, "stats_rx_msdu_invalid_len", CTLFLAG_RD,
 	    &ar->sc_stats.rx_msdu_invalid_len, "");
-	SYSCTL_ADD_QUAD(ctx, child, OID_AUTO, "stats_rx_pkt_short_len", CTLFLAG_RD,
+	SYSCTL_ADD_UQUAD(ctx, child, OID_AUTO, "stats_rx_pkt_short_len", CTLFLAG_RD,
 	    &ar->sc_stats.rx_pkt_short_len, "");
-	SYSCTL_ADD_QUAD(ctx, child, OID_AUTO, "stats_rx_pkt_zero_len", CTLFLAG_RD,
+	SYSCTL_ADD_UQUAD(ctx, child, OID_AUTO, "stats_rx_pkt_zero_len", CTLFLAG_RD,
 	    &ar->sc_stats.rx_pkt_zero_len, "");
-	SYSCTL_ADD_QUAD(ctx, child, OID_AUTO, "stats_xmit_fail_crypto_encap", CTLFLAG_RD,
+	SYSCTL_ADD_UQUAD(ctx, child, OID_AUTO, "stats_xmit_fail_crypto_encap", CTLFLAG_RD,
 	    &ar->sc_stats.xmit_fail_crypto_encap, "");
-	SYSCTL_ADD_QUAD(ctx, child, OID_AUTO, "stats_xmit_fail_mbuf_defrag", CTLFLAG_RD,
+	SYSCTL_ADD_UQUAD(ctx, child, OID_AUTO, "stats_xmit_fail_mbuf_defrag", CTLFLAG_RD,
 	    &ar->sc_stats.xmit_fail_mbuf_defrag, "");
-	SYSCTL_ADD_QUAD(ctx, child, OID_AUTO, "stats_xmit_fail_get_pbuf", CTLFLAG_RD,
+	SYSCTL_ADD_UQUAD(ctx, child, OID_AUTO, "stats_xmit_fail_get_pbuf", CTLFLAG_RD,
 	    &ar->sc_stats.xmit_fail_get_pbuf, "");
-	SYSCTL_ADD_QUAD(ctx, child, OID_AUTO, "stats_xmit_fail_htt_xmit", CTLFLAG_RD,
+	SYSCTL_ADD_UQUAD(ctx, child, OID_AUTO, "stats_xmit_fail_htt_xmit", CTLFLAG_RD,
 	    &ar->sc_stats.xmit_fail_htt_xmit, "");
 
 	/* trace stats */
-	SYSCTL_ADD_QUAD(ctx, child, OID_AUTO, "stats_trace_sent_ok",
+	SYSCTL_ADD_UQUAD(ctx, child, OID_AUTO, "stats_trace_sent_ok",
 	    CTLFLAG_RD, &ar->sc_trace.num_sent, "");
-	SYSCTL_ADD_QUAD(ctx, child, OID_AUTO, "stats_trace_sent_lost",
+	SYSCTL_ADD_UQUAD(ctx, child, OID_AUTO, "stats_trace_sent_lost",
 	    CTLFLAG_RD, &ar->sc_trace.num_lost, "");
 	SYSCTL_ADD_PROC(ctx, child, OID_AUTO, "trace_enable",
 	    CTLTYPE_INT | CTLFLAG_RW, ar, 0, athp_sysctl_trace_enable, "I", "");
-	SYSCTL_ADD_QUAD(ctx, child, OID_AUTO, "trace_mask",
+	SYSCTL_ADD_UQUAD(ctx, child, OID_AUTO, "trace_mask",
 	    CTLFLAG_RW | CTLFLAG_RWTUN,
 	    &ar->sc_trace.trace_mask, "trace mask");
 

--- a/otus/freebsd/src/sys/dev/athp/if_athp_pci.c
+++ b/otus/freebsd/src/sys/dev/athp/if_athp_pci.c
@@ -283,8 +283,6 @@ static void ath10k_pci_tasklet(void *arg)
 	trace_ath10k_intr(ar, 0, 3);
 }
 
-static void ath10k_pci_free_irq(struct ath10k_pci *ar_pci);
-
 static int ath10k_pci_request_irq_msix(struct ath10k_pci *ar_pci)
 {
 	struct ath10k *ar = &ar_pci->sc_sc;
@@ -407,7 +405,7 @@ bad:
 	return (err);
 }
 
-static int ath10k_pci_request_irq(struct ath10k_pci *ar_pci)
+int ath10k_pci_request_irq(struct ath10k_pci *ar_pci)
 {
 	struct ath10k *ar = &ar_pci->sc_sc;
 
@@ -428,7 +426,7 @@ static int ath10k_pci_request_irq(struct ath10k_pci *ar_pci)
 	return -EINVAL;
 }
 
-static void ath10k_pci_free_irq(struct ath10k_pci *ar_pci)
+void ath10k_pci_free_irq(struct ath10k_pci *ar_pci)
 {
 	struct ath10k *ar = &ar_pci->sc_sc;
 	device_t dev = ar->sc_dev;

--- a/otus/freebsd/src/sys/dev/athp/if_athp_pci.h
+++ b/otus/freebsd/src/sys/dev/athp/if_athp_pci.h
@@ -91,4 +91,7 @@ struct ath10k_pci {
 	struct callout		rx_post_retry;
 };
 
+int ath10k_pci_request_irq(struct ath10k_pci *);
+void ath10k_pci_free_irq(struct ath10k_pci *);
+
 #endif	/* __IF_ATHP_PCI_H__ */

--- a/otus/freebsd/src/sys/dev/athp/if_athp_pci_ce.c
+++ b/otus/freebsd/src/sys/dev/athp/if_athp_pci_ce.c
@@ -325,6 +325,7 @@ static inline void ath10k_ce_watermark_intr_disable(struct ath10k *ar,
 			   host_ie_addr & ~CE_WATERMARK_MASK);
 }
 
+#if 0
 static inline void ath10k_ce_error_intr_enable(struct ath10k *ar,
 					       uint32_t ce_ctrl_addr)
 {
@@ -334,6 +335,7 @@ static inline void ath10k_ce_error_intr_enable(struct ath10k *ar,
 	athp_pci_write32(ar, ce_ctrl_addr + MISC_IE_ADDRESS,
 			   misc_ie_addr | CE_ERROR_MASK);
 }
+#endif
 
 static inline void ath10k_ce_error_intr_disable(struct ath10k *ar,
 						uint32_t ce_ctrl_addr)
@@ -425,7 +427,9 @@ exit:
 void __ath10k_ce_send_revert(struct ath10k_ce_pipe *pipe)
 {
 	struct ath10k *ar = pipe->ar;
+#ifdef INVARIANTS
 	struct ath10k_pci *ar_pci = pipe->psc;
+#endif
 	struct ath10k_ce_ring *src_ring = pipe->src_ring;
 	uint32_t ctrl_addr = pipe->ctrl_addr;
 
@@ -486,7 +490,9 @@ int ath10k_ce_num_free_src_entries(struct ath10k_ce_pipe *pipe)
 int __ath10k_ce_rx_num_free_bufs(struct ath10k_ce_pipe *pipe)
 {
 //	struct ath10k *ar = pipe->ar;
+#ifdef INVARIANTS
 	struct ath10k_pci *ar_pci = pipe->psc;
+#endif
 	struct ath10k_ce_ring *dest_ring = pipe->dest_ring;
 	unsigned int nentries_mask = dest_ring->nentries_mask;
 	unsigned int write_index = dest_ring->write_index;
@@ -500,7 +506,9 @@ int __ath10k_ce_rx_num_free_bufs(struct ath10k_ce_pipe *pipe)
 int __ath10k_ce_rx_post_buf(struct ath10k_ce_pipe *pipe, void *ctx, uint32_t paddr)
 {
 	struct ath10k *ar = pipe->ar;
+#ifdef INVARIANTS
 	struct ath10k_pci *ar_pci = pipe->psc;
+#endif
 	struct ath10k_ce_ring *dest_ring = pipe->dest_ring;
 	unsigned int nentries_mask = dest_ring->nentries_mask;
 	unsigned int write_index = dest_ring->write_index;

--- a/otus/freebsd/src/sys/dev/athp/if_athp_pci_chip.c
+++ b/otus/freebsd/src/sys/dev/athp/if_athp_pci_chip.c
@@ -149,11 +149,8 @@ static const struct athp_pci_supp_chip athp_pci_supp_chips[] = {
 	{ QCA99X0_2_0_DEVICE_ID, QCA99X0_HW_2_0_CHIP_ID_REV },
 };
 
-static void ath10k_pci_buffer_cleanup(struct ath10k_pci *ar);
 static int ath10k_pci_cold_reset(struct ath10k_pci *ar);
 static int ath10k_pci_wait_for_target_init(struct ath10k_pci *ar);
-static int ath10k_pci_request_irq(struct ath10k_pci *ar);
-static void ath10k_pci_free_irq(struct ath10k_pci *ar);
 static int ath10k_pci_qca99x0_chip_reset(struct ath10k_pci *ar);
 
 static bool
@@ -387,6 +384,7 @@ ath10k_pci_enable_legacy_irq(struct ath10k_pci *ar_pci)
 				PCIE_INTR_ENABLE_ADDRESS);
 }
 
+#if 0
 static inline const char *
 ath10k_pci_get_irq_method(struct ath10k_pci *ar_pci)
 {
@@ -399,7 +397,9 @@ ath10k_pci_get_irq_method(struct ath10k_pci *ar_pci)
 
 	return "legacy";
 }
+#endif
 
+#if 0
 static uint32_t
 ath10k_pci_targ_cpu_to_ce_addr(struct ath10k_pci *ar_pci, uint32_t addr)
 {
@@ -421,6 +421,7 @@ ath10k_pci_targ_cpu_to_ce_addr(struct ath10k_pci *ar_pci, uint32_t addr)
 	val |= 0x100000 | (addr & 0xfffff);
 	return val;
 }
+#endif
 
 static void
 ath10k_pci_irq_msi_fw_mask(struct ath10k_pci *ar_pci)

--- a/otus/freebsd/src/sys/dev/athp/if_athp_pci_pipe.c
+++ b/otus/freebsd/src/sys/dev/athp/if_athp_pci_pipe.c
@@ -123,7 +123,9 @@ static int
 __ath10k_pci_rx_post_buf(struct ath10k_pci_pipe *pipe)
 {
 	struct ath10k *ar = pipe->ar;
+#ifdef INVARIANTS
 	struct ath10k_pci *ar_pci = pipe->psc;
+#endif
 	struct ath10k_ce_pipe *ce_pipe = pipe->ce_hdl;
 	struct athp_buf *pbuf;
 	int ret;
@@ -173,7 +175,9 @@ static void
 __ath10k_pci_rx_post_pipe(struct ath10k_pci_pipe *pipe)
 {
 	struct ath10k *ar = pipe->ar;
+#ifdef INVARIANTS
 	struct ath10k_pci *ar_pci = pipe->psc;
+#endif
 	struct ath10k_ce_pipe *ce_pipe = pipe->ce_hdl;
 	int ret, num;
 
@@ -227,7 +231,7 @@ ath10k_pci_rx_post(struct ath10k *ar)
  * This is the deferred RX post taskqueue entry.
  * It checks /all/ RX pipes.
  */
-static void
+void
 ath10k_pci_rx_replenish_retry(unsigned long ptr)
 {
 	struct ath10k *ar = (void *)ptr;

--- a/otus/freebsd/src/sys/dev/athp/if_athp_pci_pipe.h
+++ b/otus/freebsd/src/sys/dev/athp/if_athp_pci_pipe.h
@@ -55,5 +55,6 @@ extern	void ath10k_pci_free_pipes(struct ath10k *ar);
 extern	int ath10k_pci_init_pipes(struct ath10k *ar);
 extern	void ath10k_pci_rx_post(struct ath10k *ar);
 extern	void ath10k_pci_flush(struct ath10k *ar);
+extern	void ath10k_pci_rx_replenish_retry(unsigned long);
 
 #endif /* __ATHP_PCI_PIPE_H__ */

--- a/otus/freebsd/src/sys/dev/athp/if_athp_var.h
+++ b/otus/freebsd/src/sys/dev/athp/if_athp_var.h
@@ -64,6 +64,7 @@ struct athp_keyidx_update {
 	ieee80211_keyix keyidx;
 };
 
+#ifdef INVARIANTS
 static inline void
 athp_mtx_assert(struct mtx *mtx, int op)
 {
@@ -79,35 +80,61 @@ athp_mtx_assert(struct mtx *mtx, int op)
 	    op == MA_OWNED ? "owned" : "not-owned");
 	kdb_backtrace();
 }
+#endif
 
 #define	ATHP_NODE(ni)		((struct ath10k_sta *)(ni))
 
-#define	ATHP_LOCK(sc)		mtx_lock(&(sc)->sc_mtx)
-#define	ATHP_UNLOCK(sc)		mtx_unlock(&(sc)->sc_mtx)
-#define	ATHP_LOCK_ASSERT(sc)	athp_mtx_assert(&(sc)->sc_mtx, MA_OWNED)
-#define	ATHP_UNLOCK_ASSERT(sc)	athp_mtx_assert(&(sc)->sc_mtx, MA_NOTOWNED)
-
 #define	ATHP_FW_VER_STR		128
+
+#define	ATHP_LOCK(sc)			mtx_lock(&(sc)->sc_mtx)
+#define	ATHP_UNLOCK(sc)			mtx_unlock(&(sc)->sc_mtx)
+#ifdef INVARIANTS
+#define	ATHP_LOCK_ASSERT(sc)		athp_mtx_assert(&(sc)->sc_mtx, MA_OWNED)
+#define	ATHP_UNLOCK_ASSERT(sc)		athp_mtx_assert(&(sc)->sc_mtx, MA_NOTOWNED)
+#else
+#define	ATHP_LOCK_ASSERT(sc)		(void)0
+#define	ATHP_UNLOCK_ASSERT(sc)		(void)0
+#endif
 
 #define	ATHP_CONF_LOCK(sc)		mtx_lock(&(sc)->sc_conf_mtx)
 #define	ATHP_CONF_UNLOCK(sc)		mtx_unlock(&(sc)->sc_conf_mtx)
+#ifdef INVARIANTS
 #define	ATHP_CONF_LOCK_ASSERT(sc)	athp_mtx_assert(&(sc)->sc_conf_mtx, MA_OWNED)
 #define	ATHP_CONF_UNLOCK_ASSERT(sc)	athp_mtx_assert(&(sc)->sc_conf_mtx, MA_NOTOWNED)
+#else
+#define	ATHP_CONF_LOCK_ASSERT(sc)	(void)0
+#define	ATHP_CONF_UNLOCK_ASSERT(sc)	(void)0
+#endif
 
 #define	ATHP_DATA_LOCK(sc)		mtx_lock(&(sc)->sc_data_mtx)
 #define	ATHP_DATA_UNLOCK(sc)		mtx_unlock(&(sc)->sc_data_mtx)
+#ifdef INVARIANTS
 #define	ATHP_DATA_LOCK_ASSERT(sc)	athp_mtx_assert(&(sc)->sc_data_mtx, MA_OWNED)
 #define	ATHP_DATA_UNLOCK_ASSERT(sc)	athp_mtx_assert(&(sc)->sc_data_mtx, MA_NOTOWNED)
+#else
+#define	ATHP_DATA_LOCK_ASSERT(sc)	(void)0
+#define	ATHP_DATA_UNLOCK_ASSERT(sc)	(void)0
+#endif
 
 #define	ATHP_BUF_LOCK(sc)		mtx_lock(&(sc)->sc_buf_mtx)
 #define	ATHP_BUF_UNLOCK(sc)		mtx_unlock(&(sc)->sc_buf_mtx)
+#ifdef INVARIANTS
 #define	ATHP_BUF_LOCK_ASSERT(sc)	athp_mtx_assert(&(sc)->sc_buf_mtx, MA_OWNED)
 #define	ATHP_BUF_UNLOCK_ASSERT(sc)	athp_mtx_assert(&(sc)->sc_buf_mtx, MA_NOTOWNED)
+#else
+#define	ATHP_BUF_LOCK_ASSERT(sc)	(void)0
+#define	ATHP_BUF_UNLOCK_ASSERT(sc)	(void)0
+#endif
 
 #define	ATHP_DMA_LOCK(sc)		mtx_lock(&(sc)->sc_dma_mtx)
 #define	ATHP_DMA_UNLOCK(sc)		mtx_unlock(&(sc)->sc_dma_mtx)
+#ifdef INVARIANTS
 #define	ATHP_DMA_LOCK_ASSERT(sc)	athp_mtx_assert(&(sc)->sc_dma_mtx, MA_OWNED)
 #define	ATHP_DMA_UNLOCK_ASSERT(sc)	athp_mtx_assert(&(sc)->sc_dma_mtx, MA_NOTOWNED)
+#else
+#define	ATHP_DMA_LOCK_ASSERT(sc)	(void)0
+#define	ATHP_DMA_UNLOCK_ASSERT(sc)	(void)0
+#endif
 
 /*
  * For now, we don't allocate hardware pairwise keys as hardware

--- a/otus/freebsd/src/sys/dev/athp/if_athp_wmi.c
+++ b/otus/freebsd/src/sys/dev/athp/if_athp_wmi.c
@@ -3264,6 +3264,7 @@ static void ath10k_wmi_update_tim(struct ath10k *ar,
 		   tim->tim_bitctl, pvm_len);
 }
 
+#if 0
 static void ath10k_wmi_update_noa(struct ath10k *ar, struct ath10k_vif *arvif,
 				  struct athp_buf *bcn,
 				  const struct wmi_p2p_noa_info *noa)
@@ -3287,6 +3288,7 @@ static void ath10k_wmi_update_noa(struct ath10k *ar, struct ath10k_vif *arvif,
 #endif
 	return;
 }
+#endif
 
 static int ath10k_wmi_op_pull_swba_ev(struct ath10k *ar, struct athp_buf *pbuf,
 				      struct wmi_swba_ev_arg *arg)
@@ -3580,12 +3582,12 @@ void ath10k_wmi_event_tbttoffset_update(struct ath10k *ar, struct athp_buf *pbuf
 	ath10k_dbg(ar, ATH10K_DBG_WMI, "WMI_TBTTOFFSET_UPDATE_EVENTID\n");
 }
 
+#if 0
 static void ath10k_dfs_radar_report(struct ath10k *ar,
 				    struct wmi_phyerr_ev_arg *phyerr,
 				    const struct phyerr_radar_report *rr,
 				    u64 tsf)
 {
-#if 0
 	u32 reg0, reg1, tsf32l;
 	struct ieee80211_channel *ch;
 	struct pulse_event pe;
@@ -3671,17 +3673,16 @@ radar_detected:
 
 	ieee80211_radar_detected(ar->hw);
 
-#else
 	device_printf(ar->sc_dev, "%s: TODO: csa check! get beacon!\n", __func__);
-#endif
 }
+#endif
 
+#if 0
 static int ath10k_dfs_fft_report(struct ath10k *ar,
 				 struct wmi_phyerr_ev_arg *phyerr,
 				 const struct phyerr_fft_report *fftr,
 				 u64 tsf)
 {
-#if 0
 	u32 reg0, reg1;
 	u8 rssi, peak_mag;
 
@@ -3711,11 +3712,10 @@ static int ath10k_dfs_fft_report(struct ath10k *ar,
 		ATH10K_DFS_STAT_INC(ar, pulses_discarded);
 		return -EINVAL;
 	}
-#else
 	device_printf(ar->sc_dev, "%s: TODO!\n", __func__);
-#endif
 	return 0;
 }
+#endif
 
 void ath10k_wmi_event_dfs(struct ath10k *ar,
 			  struct wmi_phyerr_ev_arg *phyerr,

--- a/otus/freebsd/src/sys/modules/athp/Makefile
+++ b/otus/freebsd/src/sys/modules/athp/Makefile
@@ -11,7 +11,7 @@ CFLAGS+=	-I${SYSDIR}/compat/linuxkpi/common/include/
 SRCS    = if_athp_pci.c if_athp_main.c			\
 	  if_athp_debug.c				\
 	  if_athp_var.h					\
-	  bus_if.h device_if.h				\
+	  bus_if.h device_if.h pci_if.h			\
 	  opt_wlan.h
 
 # IDR from Linux


### PR DESCRIPTION
Some code cleanup.

- Make sure we compile with and without INVARIANTS in the kernel config.
- Properly indent a block.
- Make the QUAD sysctls UQUAD as it is uint64_t type members.
- Properly hide unused functions behind #if 0 rather than leaving an unused stub with a TODO printf.  We can go back to that once we actually call them.
- Do export not-really-static functions rather than having static prototypes in other files for them;  how did that ever work properly?
- Add missing if_pci.h to Makefile SRCS.

Sponsored by: Rubicon Communications, LLC (d/b/a "Netgate")
