### PR TITLE
athp: make compile with clang11

### DIFF
--- a/otus/freebsd/src/sys/dev/athp/if_athp_debug_stats.c
+++ b/otus/freebsd/src/sys/dev/athp/if_athp_debug_stats.c
@@ -527,7 +527,7 @@ unlock:
 int
 ath10k_fw_stats_open(struct ath10k *ar)
 {
-	void *buf = NULL;
+	char *buf;
 	int ret;
 
 	ATHP_CONF_LOCK(ar);


### PR DESCRIPTION
Rather than using a void * for a buffer, when we use it as a char *
declare the variable as a char *; in addition there is no need to
pre-initialise it with the current code, so remove the = NULL assignment.

Sponsored by:   Rubicon Communications, LLC (d/b/a "Netgate")