### PR TITLE
athp: regdomain setting

### DIFF
--- a/otus/freebsd/src/sys/dev/athp/if_athp_mac.c
+++ b/otus/freebsd/src/sys/dev/athp/if_athp_mac.c
@@ -3859,7 +3859,7 @@ static int ath10k_update_channel_list(struct ath10k *ar)
  * Note: this is the FreeBSD specific implementation of
  * the channel list function.
  */
-int
+static int
 ath10k_update_channel_list_freebsd(struct ath10k *ar, int nchans,
     struct ieee80211_channel *chans)
 {
@@ -3975,7 +3975,7 @@ ath10k_mac_get_dfs_region(enum nl80211_dfs_regions dfs_region)
  */
 void
 ath10k_regd_update(struct ath10k *ar, int nchans,
-    struct ieee80211_channel *chans)
+    struct ieee80211_channel *chans, struct ieee80211_regdomain *reg)
 {
 #if 0
 	struct reg_dmn_pair_mapping *regpair;
@@ -4017,11 +4017,12 @@ ath10k_regd_update(struct ath10k *ar, int nchans,
 					    regpair->reg_2ghz_ctl,
 					    regpair->reg_5ghz_ctl,
 					    wmi_dfs_reg);
-#else
 	ret = ath10k_wmi_pdev_set_regdomain(ar, 0x0, 0x0, 0x0, /* CUS223E bringup code, regdomain 0 */
 	    0x1ff, 0x1ff, /* DEBUG_REG_DMN */
 	    wmi_dfs_reg);
 #endif
+	ret = ath10k_wmi_pdev_set_regdomain(ar, reg->regdomain, reg->regdomain,
+	    reg->regdomain, 0x1ff, 0x1ff, wmi_dfs_reg);
 	if (ret)
 		ath10k_warn(ar, "failed to set pdev regdomain: %d\n", ret);
 }
@@ -5211,7 +5212,7 @@ int ath10k_start(struct ath10k *ar)
 	ar->ani_enabled = true;
 
 	ar->num_started_vdevs = 0;
-	ath10k_regd_update(ar, ic->ic_nchans, ic->ic_channels);
+	ath10k_regd_update(ar, ic->ic_nchans, ic->ic_channels, &ic->ic_regdomain);
 
 	ath10k_spectral_start(ar);
 	ath10k_thermal_set_throttling(ar);

--- a/otus/freebsd/src/sys/dev/athp/if_athp_mac2.h
+++ b/otus/freebsd/src/sys/dev/athp/if_athp_mac2.h
@@ -34,10 +34,9 @@ extern	int ath10k_add_interface(struct ath10k *ar, struct ieee80211vap *vif,
 	    const uint8_t mac[IEEE80211_ADDR_LEN]);
 extern	void ath10k_remove_interface(struct ath10k *ar, struct ieee80211vap *vif);
 
-extern	int ath10k_update_channel_list_freebsd(struct ath10k *ar,
-	    int nchans, struct ieee80211_channel *chans);
 extern	void ath10k_regd_update(struct ath10k *ar,
-	    int nchans, struct ieee80211_channel *chans);
+	    int nchans, struct ieee80211_channel *chans,
+	    struct ieee80211_regdomain *);
 
 /* key management */
 extern	bool ath10k_mac_is_peer_wep_key_set(struct ath10k *ar, const u8 *addr, u8 keyidx);

--- a/otus/freebsd/src/sys/dev/athp/if_athp_main.c
+++ b/otus/freebsd/src/sys/dev/athp/if_athp_main.c
@@ -2282,7 +2282,7 @@ athp_set_regdomain(struct ieee80211com *ic, struct ieee80211_regdomain *reg,
 	IEEE80211_UNLOCK(ic);
 	ATHP_CONF_LOCK(ar);
 	if (ar->state == ATH10K_STATE_ON)
-		(void) ath10k_regd_update(ar, nchans, chans);
+		(void) ath10k_regd_update(ar, nchans, chans, reg);
 	ATHP_CONF_UNLOCK(ar);
 	IEEE80211_LOCK(ic);
 


### PR DESCRIPTION
Pass regdomain in to ath10k_wmi_pdev_set_regdomain() updating
ath10k_regd_update() by the extra parameter.

While here make ath10k_update_channel_list_freebsd() static.

Sponsored by:	Rubicon Communications, LLC (d/b/a "Netgate")