### PR TITLE
Cleanup firmware.h #includes

### DIFF
--- a/otus/freebsd/src/sys/dev/athp/if_athp_bmi.c
+++ b/otus/freebsd/src/sys/dev/athp/if_athp_bmi.c
@@ -30,7 +30,6 @@ __FBSDID("$FreeBSD$");
 #include <sys/conf.h>
 #include <sys/bus.h>
 #include <sys/rman.h>
-#include <sys/firmware.h>
 #include <sys/module.h>
 #include <sys/taskqueue.h>
 #include <sys/condvar.h>

--- a/otus/freebsd/src/sys/dev/athp/if_athp_buf.c
+++ b/otus/freebsd/src/sys/dev/athp/if_athp_buf.c
@@ -31,7 +31,6 @@ __FBSDID("$FreeBSD$");
 #include <sys/conf.h>
 #include <sys/bus.h>
 #include <sys/rman.h>
-#include <sys/firmware.h>
 #include <sys/module.h>
 #include <sys/taskqueue.h>
 

--- a/otus/freebsd/src/sys/dev/athp/if_athp_debug.c
+++ b/otus/freebsd/src/sys/dev/athp/if_athp_debug.c
@@ -29,7 +29,6 @@ __FBSDID("$FreeBSD$");
 #include <sys/conf.h>
 #include <sys/bus.h>
 #include <sys/rman.h>
-#include <sys/firmware.h>
 #include <sys/module.h>
 #include <sys/taskqueue.h>
 #include <sys/condvar.h>

--- a/otus/freebsd/src/sys/dev/athp/if_athp_debug_stats.c
+++ b/otus/freebsd/src/sys/dev/athp/if_athp_debug_stats.c
@@ -35,7 +35,6 @@ __FBSDID("$FreeBSD$");
 #include <sys/conf.h>
 #include <sys/bus.h>
 #include <sys/rman.h>
-#include <sys/firmware.h>
 #include <sys/module.h>
 #include <sys/taskqueue.h>
 #include <sys/condvar.h>

--- a/otus/freebsd/src/sys/dev/athp/if_athp_desc.c
+++ b/otus/freebsd/src/sys/dev/athp/if_athp_desc.c
@@ -29,7 +29,6 @@ __FBSDID("$FreeBSD$");
 #include <sys/conf.h>
 #include <sys/bus.h>
 #include <sys/rman.h>
-#include <sys/firmware.h>
 #include <sys/module.h>
 #include <sys/taskqueue.h>
 #include <sys/condvar.h>

--- a/otus/freebsd/src/sys/dev/athp/if_athp_fwlog.c
+++ b/otus/freebsd/src/sys/dev/athp/if_athp_fwlog.c
@@ -30,7 +30,6 @@ __FBSDID("$FreeBSD$");
 #include <sys/conf.h>
 #include <sys/bus.h>
 #include <sys/rman.h>
-#include <sys/firmware.h>
 #include <sys/module.h>
 #include <sys/taskqueue.h>
 #include <sys/condvar.h>

--- a/otus/freebsd/src/sys/dev/athp/if_athp_htc.c
+++ b/otus/freebsd/src/sys/dev/athp/if_athp_htc.c
@@ -31,7 +31,6 @@ __FBSDID("$FreeBSD$");
 #include <sys/conf.h>
 #include <sys/bus.h>
 #include <sys/rman.h>
-#include <sys/firmware.h>
 #include <sys/module.h>
 #include <sys/taskqueue.h>
 #include <sys/condvar.h>

--- a/otus/freebsd/src/sys/dev/athp/if_athp_htt.c
+++ b/otus/freebsd/src/sys/dev/athp/if_athp_htt.c
@@ -31,7 +31,6 @@ __FBSDID("$FreeBSD$");
 #include <sys/conf.h>
 #include <sys/bus.h>
 #include <sys/rman.h>
-#include <sys/firmware.h>
 #include <sys/module.h>
 #include <sys/taskqueue.h>
 #include <sys/condvar.h>

--- a/otus/freebsd/src/sys/dev/athp/if_athp_htt_rx.c
+++ b/otus/freebsd/src/sys/dev/athp/if_athp_htt_rx.c
@@ -31,7 +31,6 @@ __FBSDID("$FreeBSD$");
 #include <sys/conf.h>
 #include <sys/bus.h>
 #include <sys/rman.h>
-#include <sys/firmware.h>
 #include <sys/module.h>
 #include <sys/taskqueue.h>
 #include <sys/condvar.h>

--- a/otus/freebsd/src/sys/dev/athp/if_athp_htt_tx.c
+++ b/otus/freebsd/src/sys/dev/athp/if_athp_htt_tx.c
@@ -31,7 +31,6 @@ __FBSDID("$FreeBSD$");
 #include <sys/conf.h>
 #include <sys/bus.h>
 #include <sys/rman.h>
-#include <sys/firmware.h>
 #include <sys/module.h>
 #include <sys/taskqueue.h>
 #include <sys/condvar.h>

--- a/otus/freebsd/src/sys/dev/athp/if_athp_ioctl.c
+++ b/otus/freebsd/src/sys/dev/athp/if_athp_ioctl.c
@@ -34,7 +34,6 @@ __FBSDID("$FreeBSD$");
 #include <sys/bus.h>
 #include <sys/rman.h>
 #include <sys/priv.h>
-#include <sys/firmware.h>
 #include <sys/module.h>
 #include <sys/taskqueue.h>
 #include <sys/condvar.h>

--- a/otus/freebsd/src/sys/dev/athp/if_athp_mac.c
+++ b/otus/freebsd/src/sys/dev/athp/if_athp_mac.c
@@ -31,7 +31,6 @@ __FBSDID("$FreeBSD$");
 #include <sys/conf.h>
 #include <sys/bus.h>
 #include <sys/rman.h>
-#include <sys/firmware.h>
 #include <sys/module.h>
 #include <sys/taskqueue.h>
 #include <sys/condvar.h>

--- a/otus/freebsd/src/sys/dev/athp/if_athp_main.c
+++ b/otus/freebsd/src/sys/dev/athp/if_athp_main.c
@@ -29,7 +29,6 @@ __FBSDID("$FreeBSD$");
 #include <sys/conf.h>
 #include <sys/bus.h>
 #include <sys/rman.h>
-#include <sys/firmware.h>
 #include <sys/module.h>
 #include <sys/taskqueue.h>
 #include <sys/condvar.h>

--- a/otus/freebsd/src/sys/dev/athp/if_athp_pci.c
+++ b/otus/freebsd/src/sys/dev/athp/if_athp_pci.c
@@ -29,7 +29,6 @@ __FBSDID("$FreeBSD$");
 #include <sys/conf.h>
 #include <sys/bus.h>
 #include <sys/rman.h>
-#include <sys/firmware.h>
 #include <sys/module.h>
 #include <sys/taskqueue.h>
 #include <sys/condvar.h>

--- a/otus/freebsd/src/sys/dev/athp/if_athp_pci_ce.c
+++ b/otus/freebsd/src/sys/dev/athp/if_athp_pci_ce.c
@@ -31,7 +31,6 @@ __FBSDID("$FreeBSD$");
 #include <sys/conf.h>
 #include <sys/bus.h>
 #include <sys/rman.h>
-#include <sys/firmware.h>
 #include <sys/module.h>
 #include <sys/taskqueue.h>
 #include <sys/condvar.h>

--- a/otus/freebsd/src/sys/dev/athp/if_athp_pci_chip.c
+++ b/otus/freebsd/src/sys/dev/athp/if_athp_pci_chip.c
@@ -31,7 +31,6 @@ __FBSDID("$FreeBSD$");
 #include <sys/conf.h>
 #include <sys/bus.h>
 #include <sys/rman.h>
-#include <sys/firmware.h>
 #include <sys/module.h>
 #include <sys/taskqueue.h>
 #include <sys/condvar.h>

--- a/otus/freebsd/src/sys/dev/athp/if_athp_pci_config.c
+++ b/otus/freebsd/src/sys/dev/athp/if_athp_pci_config.c
@@ -31,7 +31,6 @@ __FBSDID("$FreeBSD$");
 #include <sys/conf.h>
 #include <sys/bus.h>
 #include <sys/rman.h>
-#include <sys/firmware.h>
 #include <sys/module.h>
 #include <sys/taskqueue.h>
 #include <sys/condvar.h>

--- a/otus/freebsd/src/sys/dev/athp/if_athp_pci_hif.c
+++ b/otus/freebsd/src/sys/dev/athp/if_athp_pci_hif.c
@@ -31,7 +31,6 @@ __FBSDID("$FreeBSD$");
 #include <sys/conf.h>
 #include <sys/bus.h>
 #include <sys/rman.h>
-#include <sys/firmware.h>
 #include <sys/module.h>
 #include <sys/taskqueue.h>
 #include <sys/condvar.h>

--- a/otus/freebsd/src/sys/dev/athp/if_athp_pci_pipe.c
+++ b/otus/freebsd/src/sys/dev/athp/if_athp_pci_pipe.c
@@ -31,7 +31,6 @@ __FBSDID("$FreeBSD$");
 #include <sys/conf.h>
 #include <sys/bus.h>
 #include <sys/rman.h>
-#include <sys/firmware.h>
 #include <sys/module.h>
 #include <sys/taskqueue.h>
 #include <sys/condvar.h>

--- a/otus/freebsd/src/sys/dev/athp/if_athp_regio.c
+++ b/otus/freebsd/src/sys/dev/athp/if_athp_regio.c
@@ -29,7 +29,6 @@ __FBSDID("$FreeBSD$");
 #include <sys/conf.h>
 #include <sys/bus.h>
 #include <sys/rman.h>
-#include <sys/firmware.h>
 #include <sys/module.h>
 #include <sys/taskqueue.h>
 #include <sys/condvar.h>

--- a/otus/freebsd/src/sys/dev/athp/if_athp_regs.c
+++ b/otus/freebsd/src/sys/dev/athp/if_athp_regs.c
@@ -29,7 +29,6 @@ __FBSDID("$FreeBSD$");
 #include <sys/conf.h>
 #include <sys/bus.h>
 #include <sys/rman.h>
-#include <sys/firmware.h>
 #include <sys/module.h>
 #include <sys/taskqueue.h>
 #include <sys/condvar.h>

--- a/otus/freebsd/src/sys/dev/athp/if_athp_spectral.c
+++ b/otus/freebsd/src/sys/dev/athp/if_athp_spectral.c
@@ -33,7 +33,6 @@ __FBSDID("$FreeBSD$");
 #include <sys/conf.h>
 #include <sys/bus.h>
 #include <sys/rman.h>
-#include <sys/firmware.h>
 #include <sys/module.h>
 #include <sys/taskqueue.h>
 #include <sys/condvar.h>

--- a/otus/freebsd/src/sys/dev/athp/if_athp_swap.c
+++ b/otus/freebsd/src/sys/dev/athp/if_athp_swap.c
@@ -34,7 +34,6 @@ __FBSDID("$FreeBSD$");
 #include <sys/conf.h>
 #include <sys/bus.h>
 #include <sys/rman.h>
-#include <sys/firmware.h>
 #include <sys/module.h>
 #include <sys/taskqueue.h>
 #include <sys/condvar.h>

--- a/otus/freebsd/src/sys/dev/athp/if_athp_taskq.c
+++ b/otus/freebsd/src/sys/dev/athp/if_athp_taskq.c
@@ -29,7 +29,6 @@ __FBSDID("$FreeBSD$");
 #include <sys/conf.h>
 #include <sys/bus.h>
 #include <sys/rman.h>
-#include <sys/firmware.h>
 #include <sys/module.h>
 #include <sys/taskqueue.h>
 #include <sys/condvar.h>

--- a/otus/freebsd/src/sys/dev/athp/if_athp_thermal.c
+++ b/otus/freebsd/src/sys/dev/athp/if_athp_thermal.c
@@ -33,7 +33,6 @@ __FBSDID("$FreeBSD$");
 #include <sys/conf.h>
 #include <sys/bus.h>
 #include <sys/rman.h>
-#include <sys/firmware.h>
 #include <sys/module.h>
 #include <sys/taskqueue.h>
 #include <sys/condvar.h>

--- a/otus/freebsd/src/sys/dev/athp/if_athp_trace.c
+++ b/otus/freebsd/src/sys/dev/athp/if_athp_trace.c
@@ -34,7 +34,6 @@ __FBSDID("$FreeBSD$");
 #include <sys/bus.h>
 #include <sys/rman.h>
 #include <sys/proc.h>
-#include <sys/firmware.h>
 #include <sys/module.h>
 #include <sys/taskqueue.h>
 #include <sys/condvar.h>

--- a/otus/freebsd/src/sys/dev/athp/if_athp_txrx.c
+++ b/otus/freebsd/src/sys/dev/athp/if_athp_txrx.c
@@ -35,7 +35,6 @@ __FBSDID("$FreeBSD$");
 #include <sys/conf.h>
 #include <sys/bus.h>
 #include <sys/rman.h>
-#include <sys/firmware.h>
 #include <sys/module.h>
 #include <sys/taskqueue.h>
 #include <sys/condvar.h>

--- a/otus/freebsd/src/sys/dev/athp/if_athp_wmi.c
+++ b/otus/freebsd/src/sys/dev/athp/if_athp_wmi.c
@@ -33,7 +33,6 @@ __FBSDID("$FreeBSD$");
 #include <sys/conf.h>
 #include <sys/bus.h>
 #include <sys/rman.h>
-#include <sys/firmware.h>
 #include <sys/module.h>
 #include <sys/taskqueue.h>
 #include <sys/condvar.h>

--- a/otus/freebsd/src/sys/dev/athp/if_athp_wmi_tlv.c
+++ b/otus/freebsd/src/sys/dev/athp/if_athp_wmi_tlv.c
@@ -33,7 +33,6 @@ __FBSDID("$FreeBSD$");
 #include <sys/conf.h>
 #include <sys/bus.h>
 #include <sys/rman.h>
-#include <sys/firmware.h>
 #include <sys/module.h>
 #include <sys/taskqueue.h>
 #include <sys/condvar.h>


### PR DESCRIPTION
In preparation for the linuxkpi firwmare compat layer implementation,
start cleaning up the firmware.h includes splattered over all files.
Only if_athp_core.c actually needs it.

Sponsored by:   Rubicon Communications, LLC (d/b/a "Netgate")