### PR TITLE
athp: cleanup modules build Makefiles

### DIFF
--- a/otus/freebsd/src/sys/modules/athpfw/Makefile
+++ b/otus/freebsd/src/sys/modules/athpfw/Makefile
@@ -1,6 +1,6 @@
 # $FreeBSD$
 
-SUBDIR=athp_QCA988X_hw2.0_board
+SUBDIR=	 athp_QCA988X_hw2.0_board
 SUBDIR+= athp_QCA988X_hw2.0_firmware-2
 SUBDIR+= athp_QCA988X_hw2.0_firmware-4
 SUBDIR+= athp_QCA988X_hw2.0_firmware-5

--- a/otus/freebsd/src/sys/modules/athpfw/Makefile.inc
+++ b/otus/freebsd/src/sys/modules/athpfw/Makefile.inc
@@ -1,0 +1,11 @@
+# $FreeBSD$
+
+KMOD=		athp_${FWSUBDIR}_${FWNAME}
+FIRMWS=		${KMOD}:${KMOD}:1
+
+CLEANFILES=	${FWNAME}
+
+FWDIR=		${.CURDIR}/../../../contrib/dev/ath10k
+${KMOD}: ${FWDIR}/${FWSUBDIR}/${FWNAME}
+	cp ${FWDIR}/${FWSUBDIR}/${FWNAME} ${.TARGET}
+

--- a/otus/freebsd/src/sys/modules/athpfw/Makefile.inc
+++ b/otus/freebsd/src/sys/modules/athpfw/Makefile.inc
@@ -5,7 +5,7 @@ FIRMWS=		${KMOD}:${KMOD}:1
 
 CLEANFILES=	${FWNAME}
 
-FWDIR=		${.CURDIR}/../../../contrib/dev/ath10k
+FWDIR=		${.CURDIR}/../../../contrib/dev/athp
 ${KMOD}: ${FWDIR}/${FWSUBDIR}/${FWNAME}
 	cp ${FWDIR}/${FWSUBDIR}/${FWNAME} ${.TARGET}
 

--- a/otus/freebsd/src/sys/modules/athpfw/athp_QCA6174_hw2.1_board/Makefile
+++ b/otus/freebsd/src/sys/modules/athpfw/athp_QCA6174_hw2.1_board/Makefile
@@ -1,11 +1,6 @@
 # $FreeBSD$
 
-KMOD=	athp_QCA6174_hw2.1_board.bin
-FIRMWS=	athp_QCA6174_hw2.1_board.bin:athp_QCA6174_hw2.1_board.bin:1
-
-CLEANFILES=	board.bin
-
-athp_QCA6174_hw2.1_board.bin: ${.CURDIR}/../../../contrib/dev/athp/QCA6174_hw2.1/board.bin
-	cp ${.CURDIR}/../../../contrib/dev/athp/QCA6174_hw2.1/board.bin ${.TARGET}
+FWNAME=		board.bin
+FWSUBDIR=	QCA6174_hw2.1
 
 .include <bsd.kmod.mk>

--- a/otus/freebsd/src/sys/modules/athpfw/athp_QCA6174_hw2.1_firmware-5/Makefile
+++ b/otus/freebsd/src/sys/modules/athpfw/athp_QCA6174_hw2.1_firmware-5/Makefile
@@ -1,11 +1,6 @@
 # $FreeBSD$
 
-KMOD=	athp_QCA6174_hw2.1_firmware-5.bin
-FIRMWS=	athp_QCA6174_hw2.1_firmware-5.bin:athp_QCA6174_hw2.1_firmware-5.bin:1
-
-CLEANFILES=	board.bin
-
-athp_QCA6174_hw2.1_firmware-5.bin: ${.CURDIR}/../../../contrib/dev/athp/QCA6174_hw2.1/firmware-5.bin
-	cp ${.CURDIR}/../../../contrib/dev/athp/QCA6174_hw2.1/firmware-5.bin ${.TARGET}
+FWNAME=		firmware-5.bin
+FWSUBDIR=	QCA6174_hw2.1
 
 .include <bsd.kmod.mk>

--- a/otus/freebsd/src/sys/modules/athpfw/athp_QCA6174_hw3.0_board/Makefile
+++ b/otus/freebsd/src/sys/modules/athpfw/athp_QCA6174_hw3.0_board/Makefile
@@ -1,11 +1,6 @@
 # $FreeBSD$
 
-KMOD=	athp_QCA6174_hw3.0_board.bin
-FIRMWS=	athp_QCA6174_hw3.0_board.bin:athp_QCA6174_hw3.0_board.bin:1
-
-CLEANFILES=	board.bin
-
-athp_QCA6174_hw3.0_board.bin: ${.CURDIR}/../../../contrib/dev/athp/QCA6174_hw3.0/board.bin
-	cp ${.CURDIR}/../../../contrib/dev/athp/QCA6174_hw3.0/board.bin ${.TARGET}
+FWNAME=		board.bin
+FWSUBDIR=	QCA6174_hw3.0
 
 .include <bsd.kmod.mk>

--- a/otus/freebsd/src/sys/modules/athpfw/athp_QCA6174_hw3.0_firmware-4/Makefile
+++ b/otus/freebsd/src/sys/modules/athpfw/athp_QCA6174_hw3.0_firmware-4/Makefile
@@ -1,11 +1,6 @@
 # $FreeBSD$
 
-KMOD=	athp_QCA6174_hw3.0_firmware-4.bin
-FIRMWS=	athp_QCA6174_hw3.0_firmware-4.bin:athp_QCA6174_hw3.0_firmware-4.bin:1
-
-CLEANFILES=	board.bin
-
-athp_QCA6174_hw3.0_firmware-4.bin: ${.CURDIR}/../../../contrib/dev/athp/QCA6174_hw3.0/firmware-4.bin
-	cp ${.CURDIR}/../../../contrib/dev/athp/QCA6174_hw3.0/firmware-4.bin ${.TARGET}
+FWNAME=		firmware-4.bin
+FWSUBDIR=	QCA6174_hw3.0
 
 .include <bsd.kmod.mk>

--- a/otus/freebsd/src/sys/modules/athpfw/athp_QCA988X_hw2.0_board/Makefile
+++ b/otus/freebsd/src/sys/modules/athpfw/athp_QCA988X_hw2.0_board/Makefile
@@ -1,11 +1,6 @@
 # $FreeBSD$
 
-KMOD=	athp_QCA988X_hw2.0_board.bin
-FIRMWS=	athp_QCA988X_hw2.0_board.bin:athp_QCA988X_hw2.0_board.bin:1
-
-CLEANFILES=	board.bin
-
-athp_QCA988X_hw2.0_board.bin: ${.CURDIR}/../../../contrib/dev/athp/QCA988X_hw2.0/board.bin
-	cp ${.CURDIR}/../../../contrib/dev/athp/QCA988X_hw2.0/board.bin ${.TARGET}
+FWNAME=		board.bin
+FWSUBDIR=	QCA988X_hw2.0
 
 .include <bsd.kmod.mk>

--- a/otus/freebsd/src/sys/modules/athpfw/athp_QCA988X_hw2.0_firmware-2/Makefile
+++ b/otus/freebsd/src/sys/modules/athpfw/athp_QCA988X_hw2.0_firmware-2/Makefile
@@ -1,11 +1,6 @@
 # $FreeBSD$
 
-KMOD=	athp_QCA988X_hw2.0_firmware-2.bin
-FIRMWS=	athp_QCA988X_hw2.0_firmware-2.bin:athp_QCA988X_hw2.0_firmware-2.bin:1
-
-CLEANFILES=	board.bin
-
-athp_QCA988X_hw2.0_firmware-2.bin: ${.CURDIR}/../../../contrib/dev/athp/QCA988X_hw2.0/firmware-2.bin
-	cp ${.CURDIR}/../../../contrib/dev/athp/QCA988X_hw2.0/firmware-2.bin ${.TARGET}
+FWNAME=		firmware-2.bin
+FWSUBDIR=	QCA988X_hw2.0
 
 .include <bsd.kmod.mk>

--- a/otus/freebsd/src/sys/modules/athpfw/athp_QCA988X_hw2.0_firmware-4/Makefile
+++ b/otus/freebsd/src/sys/modules/athpfw/athp_QCA988X_hw2.0_firmware-4/Makefile
@@ -1,11 +1,6 @@
 # $FreeBSD$
 
-KMOD=	athp_QCA988X_hw2.0_firmware-4.bin
-FIRMWS=	athp_QCA988X_hw2.0_firmware-4.bin:athp_QCA988X_hw2.0_firmware-4.bin:1
-
-CLEANFILES=	board.bin
-
-athp_QCA988X_hw2.0_firmware-4.bin: ${.CURDIR}/../../../contrib/dev/athp/QCA988X_hw2.0/firmware-4.bin
-	cp ${.CURDIR}/../../../contrib/dev/athp/QCA988X_hw2.0/firmware-4.bin ${.TARGET}
+FWNAME=		firmware-4.bin
+FWSUBDIR=	QCA988X_hw2.0
 
 .include <bsd.kmod.mk>

--- a/otus/freebsd/src/sys/modules/athpfw/athp_QCA988X_hw2.0_firmware-5/Makefile
+++ b/otus/freebsd/src/sys/modules/athpfw/athp_QCA988X_hw2.0_firmware-5/Makefile
@@ -1,11 +1,6 @@
 # $FreeBSD$
 
-KMOD=	athp_QCA988X_hw2.0_firmware-5.bin
-FIRMWS=	athp_QCA988X_hw2.0_firmware-5.bin:athp_QCA988X_hw2.0_firmware-5.bin:1
-
-CLEANFILES=	board.bin
-
-athp_QCA988X_hw2.0_firmware-5.bin: ${.CURDIR}/../../../contrib/dev/athp/QCA988X_hw2.0/firmware-5.bin
-	cp ${.CURDIR}/../../../contrib/dev/athp/QCA988X_hw2.0/firmware-5.bin ${.TARGET}
+FWNAME=		firmware-5.bin
+FWSUBDIR=	QCA988X_hw2.0
 
 .include <bsd.kmod.mk>

--- a/otus/freebsd/src/sys/modules/athpfw/athp_QCA99X0_hw2.0_board/Makefile
+++ b/otus/freebsd/src/sys/modules/athpfw/athp_QCA99X0_hw2.0_board/Makefile
@@ -1,11 +1,6 @@
 # $FreeBSD$
 
-KMOD=	athp_QCA99X0_hw2.0_board.bin
-FIRMWS=	athp_QCA99X0_hw2.0_board.bin:athp_QCA99X0_hw2.0_board.bin:1
-
-CLEANFILES=	board.bin
-
-athp_QCA99X0_hw2.0_board.bin: ${.CURDIR}/../../../contrib/dev/athp/QCA99X0_hw2.0/board.bin
-	cp ${.CURDIR}/../../../contrib/dev/athp/QCA99X0_hw2.0/board.bin ${.TARGET}
+FWNAME=		board.bin
+FWSUBDIR=	QCA99X0_hw2.0
 
 .include <bsd.kmod.mk>

--- a/otus/freebsd/src/sys/modules/athpfw/athp_QCA99X0_hw2.0_firmware-5/Makefile
+++ b/otus/freebsd/src/sys/modules/athpfw/athp_QCA99X0_hw2.0_firmware-5/Makefile
@@ -1,11 +1,6 @@
 # $FreeBSD$
 
-KMOD=	athp_QCA99X0_hw2.0_firmware-5.bin
-FIRMWS=	athp_QCA99X0_hw2.0_firmware-5.bin:athp_QCA99X0_hw2.0_firmware-5.bin:1
-
-CLEANFILES=	board.bin
-
-athp_QCA99X0_hw2.0_firmware-5.bin: ${.CURDIR}/../../../contrib/dev/athp/QCA99X0_hw2.0/firmware-5.bin
-	cp ${.CURDIR}/../../../contrib/dev/athp/QCA99X0_hw2.0/firmware-5.bin ${.TARGET}
+FWNAME=		firmware-5.bin
+FWSUBDIR=	QCA99X0_hw2.0
 
 .include <bsd.kmod.mk>


### PR DESCRIPTION
The Makefiles had a lot of copy and paste and especially CLEANFILES
was wrong in some of them.
Rather than keeping the duplicate logic everywhere, put it into
a common Makefile.inc and only have the per-firmware kmod specifics
in the individual Makefiles.
This will also allow us to change the way we are building the
firmware(9) kernel modules in a single place.

Sponsored by:   Rubicon Communications, LLC (d/b/a "Netgate")